### PR TITLE
Remove direct dependency on Fmt

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -1,7 +1,7 @@
 (executable
  (name test)
  (preprocess (pps ppx_let))
- (libraries alcotest alcotest-async fmt thread_pool))
+ (libraries alcotest alcotest-async thread_pool))
 
 (alias
  (name runtest)

--- a/thread-pool-async.opam
+++ b/thread-pool-async.opam
@@ -14,5 +14,4 @@ depends: [
   "ppx_let" {>= "v0.9" & < "v0.12"}
   "alcotest" {test}
   "alcotest-async" {test}
-  "fmt" {test}
 ]


### PR DESCRIPTION
What it says. We don't use `Fmt` anymore, so don't link to it.