### PR TITLE
Potential fix for hanging behaviour

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+* Fixed bug that was causing the pool to get stuck (hang) while it was
+  destroying itself. This bug could easily be triggered when state creation or
+  destruction failed.
+
 0.13.0
 ======
 

--- a/src/thread_pool_async.ml
+++ b/src/thread_pool_async.ml
@@ -135,4 +135,4 @@ let with' pool ?(retries = 0) work =
   let job worker = execute worker work in
   with_worker pool ~retries job
 
-let destroy pool = destroy_pool pool
+let destroy = destroy_pool

--- a/test/test.ml
+++ b/test/test.ml
@@ -192,10 +192,7 @@ let test_multiple_concurrent_destructions () =
   let destroy () = raise State_creation_error in
   let%bind pool = Thread_pool.init ~name:"unittest" ~threads ~create ~destroy in
   let provoke_pool_destruction () = Thread_pool.with' pool (fun _ -> Error ()) in
-  let%bind () =
-    check_exceptions @@ List.init (threads + 1) ~f:(fun _ -> provoke_pool_destruction)
-  in
-  return ()
+  check_exceptions @@ List.init (threads + 1) ~f:(fun _ -> provoke_pool_destruction)
 
 let test_case = Alcotest_async.test_case
 


### PR DESCRIPTION
Note that I tuned down on the number of threads in the unit tests. This is because it seems like the helper threads never get returned back to `Async` (I couldn't find any function that would let us force returning them either) and eventually the `Async` pool just has no threads left and the whole thing dies.

We could consider using a separate [thread pool](https://ocaml.janestreet.com/ocaml-core/latest/doc/async_unix/Thread_pool/index.html) instead of helper threads (in a future version).